### PR TITLE
Make the location of the db-file configurable

### DIFF
--- a/config/default.json.example
+++ b/config/default.json.example
@@ -7,5 +7,6 @@
     "bucket_url": "https://s3-eu-west-1.amazonaws.com/bucket"
   },
   "originals_dir": "images",
-  "listen_address": "127.0.0.1"
+  "listen_address": "127.0.0.1",
+  "db_file": "/tmp/db.cache"
 }

--- a/prepare.js
+++ b/prepare.js
@@ -2,7 +2,8 @@
 
 // This file should only run to craete the database and assumes no database is present
 var sqlite3 = require('sqlite3').verbose();
-var db = new sqlite3.Database('cache.db');
+var config = require('config');
+var db = new sqlite3.Database(config.get('db_file'));
 
 db.serialize(function () {
     db.run("CREATE TABLE images (id VARCHAR(255), x INT(6), y INT(6), file_type VARCHAR(8), url VARCHAR(255))");

--- a/resize.js
+++ b/resize.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var config = require('config');
 var AWS = require('aws-sdk');
 var sqlite3 = require('sqlite3').verbose();
-var db = new sqlite3.Database('cache.db');
+var db = new sqlite3.Database(config.get('db_file'));
 var uuid = require('node-uuid');
 var bodyParser = require('body-parser');
 


### PR DESCRIPTION
From a standpoint of deployment, it makes sense to allow an operator to specify where the database should be located (just as was already happening for the `originals_dir`). This PR fixes that

@inventid/tech @inventid/magnet-collaboration please review!