### PR TITLE
Log requests and response times

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fs-extra": "^0.18.4",
     "gm": "^1.17.0",
     "node-uuid": "^1.4.2",
+    "response-time": "^2.3.1",
     "sqlite3": "^3.0.5"
   },
   "devDependencies": {},

--- a/resize.js
+++ b/resize.js
@@ -7,9 +7,10 @@ var fs = require('fs-extra');
 var config = require('config');
 var AWS = require('aws-sdk');
 var sqlite3 = require('sqlite3').verbose();
-var db;
+var responseTime = require('response-time')
 var uuid = require('node-uuid');
 var bodyParser = require('body-parser');
+var db;
 
 AWS.config.update({accessKeyId: config.get('aws.access_key'), secretAccessKey: config.get('aws.secret_key'), region: config.get('aws.region')});
 
@@ -52,6 +53,32 @@ function log(level, message) {
     console.log(JSON.stringify(obj));
 }
 
+function logRequest(req, res, time) { //image, resX, resY, cache) {
+    var obj = {
+        method: req.method,
+        url: req.url,
+        client: req.ip,
+        response_time: (time/1e3),
+        response_status: res.statusCode
+    };
+    if(isGetRequest(req, res)) {
+        if(res.statusCode === 200) {
+            obj.cache_hit = false;
+        } else if (res.statusCode === 307) {
+            obj.cache_hit = true
+        }
+        var imageParams = getImageParams(req.url);
+        for(var param in imageParams) {
+            obj[param] = imageParams[param];
+        }
+    }
+    console.log(JSON.stringify(obj));
+}
+
+function isGetRequest(req, res) {
+    return req.url !== '/healthcheck' && req.method === 'GET';
+}
+
 function supportedFileType(fileType) {
     switch (fileType) {
     case 'jpg':
@@ -66,10 +93,33 @@ function supportedFileType(fileType) {
     }
 }
 
+function isValidRequest(url) {
+    return splitUrl(url) !== null;
+}
+
+function splitUrl(url) {
+    return url.match(/^\/(.*)_(\d+)_(\d+)(_(\d+)x)?\.(.*)/);
+}
+
+function getImageParams(url) {
+    var matches = splitUrl(url);
+    var res = {
+       fileName: matches[1],
+       resolutionX: parseInt(matches[2], 10),
+       resolutionY: parseInt(matches[3], 10),
+       fileType: matches[6].toLowerCase()
+    }
+
+    if (matches[5] !== undefined) {
+        res.resolutionX *= parseInt(matches[5], 10);
+        res.resolutionY *= parseInt(matches[5], 10);
+    }
+    return res;
+}
+
 var image = {};
 image.get = function (req, res) {
-    var matches = req.url.match(/^\/(.*)_(\d+)_(\d+)(_(\d+)x)?\.(.*)/);
-    if (matches === null) {
+    if (!isValidRequest(req.url)) {
         // Invalid URL
         log('error', '404 Error for ' + res.url);
         res.writeHead(404, 'File not found');
@@ -77,23 +127,18 @@ image.get = function (req, res) {
         return;
     }
 
-    var fileName = matches[1], resolutionX = parseInt(matches[2], 10), resolutionY = parseInt(matches[3], 10);
-    if (matches[5] !== undefined) {
-        resolutionX *= parseInt(matches[5], 10);
-        resolutionY *= parseInt(matches[5], 10);
-    }
-    var fileType = matches[6].toLowerCase();
+    var params = getImageParams(req.url);
 
-    if (supportedFileType(fileType) === null) {
-        log('error', 'Filetype ' + fileType + ' is not supported');
+    if (supportedFileType(params.fileType) === null) {
+        log('error', 'Filetype ' + params.fileType + ' is not supported');
         res.writeHead(415, 'Unsupported media type');
         res.end();
         return;
     }
 
-    log('info', 'Requesting file ' + fileName + ' in ' + fileType + ' format in a ' + resolutionX + 'x' + resolutionY + 'px resolution');
+    log('info', 'Requesting file ' + params.fileName + ' in ' + params.fileType + ' format in a ' + params.resolutionX + 'x' + params.resolutionY + 'px resolution');
 
-    image.checkCacheOrCreate(fileName, fileType, resolutionX, resolutionY, res);
+    image.checkCacheOrCreate(params.fileName, params.fileType, params.resolutionX, params.resolutionY, res);
 };
 image.checkCacheOrCreate = function (fileName, fileType, resolutionX, resolutionY, res) {
     // Check if it exists in the cache
@@ -275,10 +320,12 @@ function startServer() {
     // Create the server
     var app = express();
     app.use(bodyParser.json());
+    app.use(responseTime(logRequest));
     app.get('/healthcheck', serverStatus);
     app.get('/*', image.get);
     app.post('/token', token.create);
     app.post('/*', image.upload);
+    
     
     // And listen!
     var server = app.listen(1337, function () {


### PR DESCRIPTION
Closes #5 

Make much more verbose logging

```
Using db file: /tmp/db.cache
Server started listening
{"datetime":1433709090509,"severity":"info","message":"Requesting file test in png format in a 400x402px resolution"}
{"datetime":1433709090514,"severity":"info","message":"cache hit for test.png(400x402px)"}
{"datetime":1433709090515,"method":"GET","url":"/test_200_201_2x.png","client":"10.0.2.2","response_time":0.006659376,"response_status":307,"cache_hit":true,"fileName":"test","resolutionX":400,"resolutionY":402,"fileType":"png"}
{"datetime":1433709096751,"severity":"info","message":"Requesting file test in png format in a 1000x1005px resolution"}
{"datetime":1433709096754,"method":"GET","url":"/test_200_201_5x.png","client":"10.0.2.2","response_time":0.002655131,"response_status":200,"cache_hit":false,"fileName":"test","resolutionX":1000,"resolutionY":1005,"fileType":"png"}
{"datetime":1433709100495,"severity":"info","message":"Finished sending a converted image"}
{"datetime":1433709108360,"severity":"info","message":"Uploading of test_1000x1005.png went very well"}
```
