### PR TITLE
Improve dockerfile to leverage container caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,16 @@ MAINTAINER Rogier Slag
 RUN apt-get install -y software-properties-common python && \
     add-apt-repository ppa:chris-lea/node.js && \
     apt-get remove -y software-properties-common python && \
-    apt-get autoremove -y
+    apt-get autoremove -y && \
+    apt-get clean
 RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ precise universe" >> /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y imagemagick build-essential sqlite3 make gcc nodejs && \
-    apt-get autoremove -y
-
-# Add the application
-ADD resize.js /opt/live-image-resize/resize.js
-ADD package.json /opt/live-image-resize/package.json
+    apt-get autoremove -y && \
+    apt-get clean
 
 # Export the database, originals dir and the config dir
+RUN mkdir /opt/live-image-resize
 RUN mkdir /opt/live-image-resize/config
 RUN mkdir /opt/images
 RUN mkdir /opt/db
@@ -23,11 +22,12 @@ RUN chmod 0777 /opt/db
 VOLUME ["/opt/db", "/opt/images", "/opt/live-image-resize/config"]
 EXPOSE 1337
 
-# Set the correct version of node as the default
+# Add the dependencies
+ADD package.json /opt/live-image-resize/package.json
 RUN cd /opt/live-image-resize && npm install
 
-# Decrease the file size a bit
-RUN apt-get clean
+# Add the application
+ADD resize.js /opt/live-image-resize/resize.js
 
 # Run the entire thing!
 WORKDIR /opt/live-image-resize


### PR DESCRIPTION
This improves the dockerfile by moving stuff around.

By adding the dependencies before the application, we do not need to run npm install every time when dockerizing the app, since `package.json` has not been updated then. To be honest, we probably only need to run the last three commands now, since the remainder can be cached perfectly

@alexnederlof ready for review!