### PR TITLE
Use robots.txt for crawler handling

### DIFF
--- a/config/default.json.example
+++ b/config/default.json.example
@@ -8,5 +8,6 @@
   },
   "originals_dir": "/opt/images",
   "listen_address": "127.0.0.1",
-  "db_file": "/opt/db.cache"
+  "db_file": "/opt/db.cache",
+  "allow_indexing": false
 }

--- a/resize.js
+++ b/resize.js
@@ -370,6 +370,17 @@ function serverStatus(req, res) {
   log('info', 'healthcheck performed');
 }
 
+function robotsTxt(req, res) {
+  res.writeHead(200, 'OK');
+  if ( config.has('allow_indexing') && config.get('allow_indexing') ) {
+    res.write("User-agent: *\nAllow: /");
+  } else {
+    res.write("User-agent: *\nDisallow: /");
+  }
+  res.end();
+  log('info', 'robots.txt served');
+}
+
 function startServer() {
   // Set the queries
   insertImage = db.prepare("INSERT INTO images (id, x, y, file_type, url) VALUES (?,?,?,?,?)");
@@ -383,6 +394,7 @@ function startServer() {
   app.use(bodyParser.json());
   app.use(responseTime(logRequest));
   app.get('/healthcheck', serverStatus);
+  app.get('/robots.txt', robotsTxt);
   app.get('/*_*_*_*x.*', image.get);
   app.get('/*_*_*.*', image.get);
   app.get('/*.*', image.getOriginal);


### PR DESCRIPTION
@joostverdoorn @alexnederlof @TiddoLangerak Ready for review

For inventid, we do not want indexing of these images, so we set the variable `allow_indexing` to `false` (the default). Meanwhile Magnetme might want to allow indexing for this, so they can override the value in the configuration json.

This also prevents crawlers from hitting 404s, or longer waiting times.