### PR TITLE
Introduce limits on the requested image dimensions

### DIFF
--- a/config/default.json.example
+++ b/config/default.json.example
@@ -9,5 +9,9 @@
   "originals_dir": "/opt/images",
   "listen_address": "127.0.0.1",
   "db_file": "/opt/db.cache",
-  "allow_indexing": false
+  "allow_indexing": false,
+  "constraints": {
+    "max_width": 2000,
+    "max_height": 2000
+  }
 }

--- a/resize.js
+++ b/resize.js
@@ -147,6 +147,12 @@ image.get = function (req, res) {
     return;
   }
 
+  if (params.resolutionX < 0 || params.resolutionY < 0 || params.resolutionX > config.get('constraints.max_width') || params.resolutionY > config.get('constraints.max_height')) {
+    res.writeHead(400, 'Bad request');
+    res.end('The requested image size falls outside of the allowed boundaries of this service.');
+    return;
+  }
+
   log('info', 'Requesting file ' + params.fileName + ' in ' + params.fileType + ' format in a ' + params.resolutionX + 'x' + params.resolutionY + 'px resolution');
 
   image.checkCacheOrCreate(params.fileName, params.fileType, params.resolutionX, params.resolutionY, res);


### PR DESCRIPTION
This limits the sizes of images to a maximum width and height to ensure nobody can simply ddos the service by requesting insanely large pictures

@inventid/tech @alexnederlof @TiddoLangerak @michaeldejong @alexwalterbos