### PR TITLE
Removed redirect on HEAD request

### DIFF
--- a/dist/resize.js
+++ b/dist/resize.js
@@ -75,9 +75,23 @@ var image = {
     if (!valid) {
       return helpers.send307DueTooLarge(res, params);
     }
+    if (req.method === 'HEAD') {
+      image.canServeFile(params, function (canServe) {
+        if (canServe) {
+          res.status(200).end();
+        } else {
+          res.status(404).end();
+        }
+      });
+      return;
+    }
     log.log('info', 'Requesting file ' + params.fileName + ' in ' + params.fileType + ' format in a ' + params.resolutionX + 'x' + params.resolutionY + 'px resolution');
 
     image.checkCacheOrCreate(params, res);
+  },
+  canServeFile: function canServeFile(params, cb) {
+    var file = config.get('originals_dir') + '/' + params.fileName;
+    fs.exists(file, cb);
   },
   checkCacheOrCreate: function checkCacheOrCreate(params, res) {
     // Check if it exists in the cache

--- a/resize.js
+++ b/resize.js
@@ -77,9 +77,25 @@ const image = {
     if (!valid) {
       return helpers.send307DueTooLarge(res, params);
     }
+    //HEAD requests won't be redirected automatically, so instead we'll always either return a 200
+    //or a 404, indicating if the corresponding GET method will result in an image.
+    if (req.method === 'HEAD') {
+      image.canServeFile(params, (canServe) => {
+        if (canServe) {
+          res.status(200).end();
+        } else {
+          res.status(404).end();
+        }
+      });
+      return;
+    }
     log.log('info', `Requesting file ${params.fileName} in ${params.fileType} format in a ${params.resolutionX}x${params.resolutionY}px resolution`);
 
     image.checkCacheOrCreate(params, res);
+  },
+  canServeFile(params, cb) {
+      var file = config.get('originals_dir') + '/' + params.fileName;
+      fs.exists(file, cb);
   },
   checkCacheOrCreate(params, res) {
     // Check if it exists in the cache


### PR DESCRIPTION
`HEAD` request won't automatically get redirected by browsers. It is therefore more useful to resolve the redirect already internally, such that clients can detect if the image can be found without having to perform an explicit extra request. This is also needed for some libraries to work correctly (e.g. the [angular-retina](https://github.com/jrief/angular-retina) library we use at Magnet.me).

@rogierslag @joostverdoorn @wouter-willems - RFR!