### PR TITLE
Enabled interlacing for jpegs

### DIFF
--- a/dist/resize.js
+++ b/dist/resize.js
@@ -262,6 +262,10 @@ function correctlyResize(file, params, callback) {
     } else {
       workImageClient = workImageClient.resize(params.resolutionX, params.resolutionY);
     }
+    //Interlacing for png isn't efficient (both in filesize as render performance), so we only do it for jpg
+    if (params.fileType === 'jpg') {
+      workImageClient = workImageClient.interlace('Line');
+    }
     callback(workImageClient);
   });
 }

--- a/resize.js
+++ b/resize.js
@@ -269,6 +269,10 @@ function correctlyResize(file, params, callback) {
     } else {
       workImageClient = workImageClient.resize(params.resolutionX, params.resolutionY);
     }
+    //Interlacing for png isn't efficient (both in filesize as render performance), so we only do it for jpg
+    if (params.fileType === 'jpg') {
+      workImageClient = workImageClient.interlace('Line');
+    }
     callback(workImageClient);
   });
 }


### PR DESCRIPTION
It's the difference between this:
![non-interlaced](https://cloud.githubusercontent.com/assets/1759192/10132918/7f0a8610-65d9-11e5-8968-9a744414c456.gif)

And this (stopped recording early, but you get the point :wink:):
![interlacing](https://cloud.githubusercontent.com/assets/1759192/10132919/82599e96-65d9-11e5-8855-fbb7b38942b9.gif)

@rogierslag @joostverdoorn @wouter-willems @alexnederlof - RFR