### PR TITLE
Switch from PM2 to node itself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN npm install -g pm2 babel-cli babel-preset-es2015
+RUN npm install -g babel-cli babel-preset-es2015
 
 # Export the database, originals dir and the config dir
 RUN mkdir /opt/live-image-resize
@@ -29,4 +29,5 @@ RUN cd /opt/live-image-resize/src && babel -d ../ *.js
 
 # Run the entire thing!
 WORKDIR /opt/live-image-resize
-CMD ["/usr/local/bin/pm2", "start", "index.js", "--no-daemon", "--instances=2"]
+CMD ["node", "index.js"]
+


### PR DESCRIPTION
On closer inspection, this gives operators a better method for failovering by doing this explicitly instead of implicitly within the container. The latter will force more memory consumption, make hateful logs, and is more difficult to check whether an instance had a problem and was auto restarted

@joostverdoorn @alexnederlof Please check whether you agree with the reasoning here