### PR TITLE
Allow optional cropping of images while uploading

### DIFF
--- a/Helpers.js
+++ b/Helpers.js
@@ -32,6 +32,11 @@ const Helpers = {
     res.setHeader('Access-Control-Allow-Method', 'GET');
     next();
   },
+  send400(res, message = '') {
+    log.log('warning', `Invalid request was done: ${message}`);
+    res.statusCode = 400;
+    res.end(message);
+  },
   send404(res, url, error = true) {
     if (error) {
       log.log('warning', `404 Error for ${url}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "live-image-resize",
-  "version": "0.1.1",
+  "version": "1.1.0",
   "description": "Dynamic image resizing service, using AWS S3 as a cache",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
As requested by @wouter-willems, setting the query parameters `x`, `y`, `width` and `height` allow to crop the picture when uploading. This prevents cropping weirdness in the browser if we handle it using javascript

Ready for review @TiddoLangerak @joostverdoorn @wouter-willems 