### PR TITLE
Allow for canvas parsing

### DIFF
--- a/UrlParsing.js
+++ b/UrlParsing.js
@@ -9,7 +9,7 @@
  * [5] The scaling parameter (for retina)
  * [6] The file type
  * [7] The query string, dont use this, use [8] instead
- * [8] The format (either clip or crop)
+ * [8] The format (either clip or crop or canvas)
  * @param url The url to parse
  * @returns {Array|{index: number, input: string}|*|{ID, CLASS, NAME, ATTR, TAG, CHILD, POS, PSEUDO}}
  */
@@ -62,7 +62,7 @@ const UrlParsing = {
         fit: 'clip'
       };
 
-      if (matches[8] && ['clip', 'crop'].indexOf(matches[8].toLowerCase()) > -1) {
+      if (matches[8] && ['clip', 'crop', 'canvas'].indexOf(matches[8].toLowerCase()) > -1) {
         res.fit = matches[8].toLowerCase();
       }
 

--- a/index.js
+++ b/index.js
@@ -101,6 +101,9 @@ function correctlyResize(file, params, callback) {
     } else {
       workImageClient = workImageClient.resize(params.resolutionX, params.resolutionY);
     }
+    if (params.fit === 'canvas') {
+      workImageClient = workImageClient.gravity('Center').extent(params.resolutionX, params.resolutionY);
+    }
     //Interlacing for png isn't efficient (both in filesize as render performance), so we only do it for jpg
     if (params.fileType === 'jpg') {
       workImageClient = workImageClient.interlace('Line');

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,9 +3,7 @@ language: node_js
 notifications:
   email: false
 
-install:
-  - npm install eslint -g
-
-script:
-  - eslint .
-
+build:
+  ci:
+    - npm install eslint -g
+    - eslint .


### PR DESCRIPTION
<img width="289" alt="screenshot 2016-05-02 16 46 55" src="https://cloud.githubusercontent.com/assets/2778689/14957427/a3ba6a6e-1085-11e6-9492-88a518a75c5f.png">

This is the same as fitting the image, but additionally it fills the bordesr until the exact desired height and width

@wouter-willems for review

After merging we can switch to the `beta` branch for testing