### PR TITLE
Optionally blur images when adding a blur=true query parameter

### DIFF
--- a/migrations/20160627164931.sql
+++ b/migrations/20160627164931.sql
@@ -1,0 +1,4 @@
+ALTER TABLE images ADD COLUMN blur boolean DEFAULT 'f';
+DROP INDEX unique_image;
+
+CREATE UNIQUE INDEX unique_image ON images(id,x,y,fit,file_type,blur);


### PR DESCRIPTION
@maartenkar @alexnederlof @TiddoLangerak @wouter-willems 

This adds the ability to blur images to a certain extent. It is still possible to backtrack the original image and omit the `?blur=true` though.

Had to rewrite some logic so we can combine all the query parameter options. But it works

So now the following image

![screenshot 2016-06-27 16 42 54](https://cloud.githubusercontent.com/assets/2778689/16383783/c840c842-3c86-11e6-823a-6715ab7da664.png)

Can be served as 

![screenshot 2016-06-27 16 42 48](https://cloud.githubusercontent.com/assets/2778689/16384183/451e5d42-3c88-11e6-9069-d94ed7eb6a48.png)

Options are chainable and the results are saved to AWS as well