### PR TITLE
Add option to guard token requests with a secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The following settings are supported:
 | webp.allow_opt_in | Setting this flag to `true` allows clients to add the `allow_webp` (set to `true`) to dynamically switch to the webp format, if supported by the requesting browser |
 | webp.allow_dynamic_switch | Setting this flag to `true` switches all clients which support WebP to get an WebP image instead of the requested format |
 | redis.url | An URL to a redis instance for additional caching of any redirects |
+| secret | A potential secret key which the server and the client need to exchange in order to obtain a token. The secret key should be sent as part of the `POST /token` in `secret` variable. |
 
 
 ### Database

--- a/config/default.example.json
+++ b/config/default.example.json
@@ -29,5 +29,6 @@
   "webp": {
     "allow_dynamic_switch": false,
     "allow_opt_in": true
-  }
+  },
+  "secret": "1234hvhv1234hvp"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -217,6 +217,12 @@ server.get('/(:name).(:format)', (req, res) => {
 
 // The upload stuff
 server.post('/token', async (req, res) => {
+  // If we have a secret key configured, check whether it matches first
+  if (config.has('secret') && config.get('secret') !== req.body.secret) {
+    res.status(401).json({error: 'A secret key is required for this server, and it was not supplied or incorrect'});
+    return;
+  }
+
   // Create a token
   const image = req.body.id;
   const metric = timingMetric(REQUEST_TOKEN, {fields: {name: image}});


### PR DESCRIPTION
This allows one to not shield the `/token` endpoint using a firewall, but by configuring a secret key which is only known within the trusted network.