### PR TITLE
Image size cache

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -87,6 +87,6 @@ export default async (name, params, data) => {
   } catch (e) {
     log('error', e);
   }
-  await fastCache.addToCache(params, url);
+  await fastCache.addImageToCache(params, url);
 };
 

--- a/src/caches/redis.js
+++ b/src/caches/redis.js
@@ -59,17 +59,21 @@ export default function redis() {
   }
 
   async function addImageToCache(params, url) {
-      return addToTempCache(key(params), url, 'addImageToCache')
+      return addToTempCache(key(params), url, 'addImageToCache');
   }
 
-  async function getSizeFromCache(params) {
-    return getFromCache(key(params), 'getSizeFromCache');
+  async function getSizeFromCache(path) {
+    const cacheValue = await getFromCache(`___original-size-${path}`, 'getSizeFromCache');
+    if (cacheValue) {
+      return JSON.parse(cacheValue);
+    }
+
+    return null;
   }
 
-  async function addSizeToCache(params, url) {
-    return addToCache(key(params), url, 'addSizeToCache')
+  async function addSizeToCache(path, data) {
+    return addToCache(`___original-size-${path}`, JSON.stringify(data), 'addSizeToCache');
   }
-
 
   function close() {
     client.quit();
@@ -80,6 +84,6 @@ export default function redis() {
     addImageToCache,
     getImageFromCache,
     getSizeFromCache,
-    addSizeToCache,
+    addSizeToCache
   };
 }

--- a/src/fastCache.js
+++ b/src/fastCache.js
@@ -1,21 +1,40 @@
 import log from "./log";
 import cache from "./caches";
 
-export async function getFromCache(params) {
+export async function getImageFromCache(params) {
   try {
     if (cache === null) {
       return null;
     }
-    return await cache.getFromCache(params);
+    return await cache.getImageFromCache(params);
   } catch (e) {
     log('error', e.toString());
     return null;
   }
 }
 
-export async function addToCache(params, url) {
+export async function addImageToCache(params, url) {
   if (cache === null) {
     return;
   }
-  await cache.addToCache(params, url);
+  await cache.addImageToCache(params, url);
+}
+
+export async function getSizeFromCache(params) {
+  try {
+    if (cache === null) {
+      return null;
+    }
+    return await cache.getSizeFromCache(params);
+  } catch (e) {
+    log('error', e.toString());
+    return null;
+  }
+}
+
+export async function addSizeToCache(params, url) {
+  if (cache === null) {
+    return;
+  }
+  await cache.addSizeToCache(params, url);
 }

--- a/src/image.js
+++ b/src/image.js
@@ -160,6 +160,18 @@ export async function magic(file, params) {
   return client;
 }
 
+export async function imageSize(path) {
+  // Check whether we have this thing in cache first
+  const cacheResult = await fastCache.getSizeFromCache(path);
+  if (cacheResult) {
+    return cacheResult;
+  }
+  const result = await size(im(path).options(gmOptions));
+  // Dont wait for adding it to the cache
+  fastCache.addSizeToCache(path, result);
+  return result;
+}
+
 export async function writeOriented(source, destination, cropParameters) {
   // if possible, crop first (since the UA had that orientation), then orient
   if (cropParameters) {
@@ -196,18 +208,6 @@ export async function writeOriented(source, destination, cropParameters) {
       originalWidth: null
     };
   }
-}
-
-export async function imageSize(path) {
-  // Check whether we have this thing in cache first
-  const cacheResult = await fastCache.getSizeFromCache(path);
-  if (cacheResult) {
-    return cacheResult;
-  }
-  const result = await size(im(path).options(gmOptions));
-  // Dont wait for adding it to the cache
-  fastCache.addSizeToCache(path, result);
-  return result;
 }
 
 export async function imageArea(path) {

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -152,6 +152,7 @@ export async function magic(params, method, response, stats = undefined, metric 
       redirectImageToWithinBounds(await calculateNewBounds(params), response);
       if (metric) {
         metric.addTag('status', 307);
+        metric.addTag('withinBounds', false);
         metrics.write(metric);
       }
       return;
@@ -174,6 +175,7 @@ export async function magic(params, method, response, stats = undefined, metric 
       redirectToCachedEntity(fastCacheValue, params, response);
       if (metric) {
         metric.addTag('cacheHit', true);
+        metric.addTag('withinBounds', true);
         metric.addTag('status', 200);
         metric.stop();
         metrics.write(metric);
@@ -193,6 +195,7 @@ export async function magic(params, method, response, stats = undefined, metric 
       if (metric) {
         metric.addFields(dbCache.stats());
         metric.addTag('status', 200);
+        metric.addTag('withinBounds', true);
         metric.stop();
         metrics.write(metric);
         metrics.write(metric.copy(REDIRECT));
@@ -219,6 +222,7 @@ export async function magic(params, method, response, stats = undefined, metric 
       if (metric) {
         metric.addFields(dbCache.stats());
         metric.addTag('status', 200);
+        metric.addTag('withinBounds', true);
         metric.stop();
         metrics.write(metric);
         metrics.write(metric.copy(GENERATION));

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -168,7 +168,7 @@ export async function magic(params, method, response, stats = undefined, metric 
     }
     log('debug', `Request for ${imageDescription}`);
 
-    const fastCacheValue = await fastCache.getFromCache(params);
+    const fastCacheValue = await fastCache.getImageFromCache(params);
     if (fastCacheValue) {
       log('debug', `Fast cache hit for ${imageDescription}`);
       redirectToCachedEntity(fastCacheValue, params, response);
@@ -197,7 +197,7 @@ export async function magic(params, method, response, stats = undefined, metric 
         metrics.write(metric);
         metrics.write(metric.copy(REDIRECT));
       }
-      await fastCache.addToCache(params, cacheValue);
+      await fastCache.addImageToCache(params, cacheValue);
       return;
     }
     if (stats) {


### PR DESCRIPTION
This adds a fast cache to have the image sizes cached. Images which are requested outside bounds should be served quicker as no loading from disk is required

Flyby: indicate in metrics how often images outside bounds are requested