### PR TITLE
Differentiate cached redirects from out of bound redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Logging takes place in a JSON Logstash enabled format, so it's easy to get into 
 | Code | When | Explanation |
 |---|---|---|
 | `200` | Always | Everything went as expected |
-| `307` | Requesting | The image is prerendered, and the client is redirected to the cached value. No `X-Redirect-Info` header is set. |
+| `303` | Requesting | The image is prerendered, and the client is redirected to the cached value. No `X-Redirect-Info` header is set. |
 | `307` | Requesting | The image was outside the maximum bounds. The client will be redirected to the maximum image size instead. The `X-Redirect-Info` header is set. |
 | `400` | Requesting | The image parameters were not correctly set. |
 | `400` | Token | The `id` was not correctly posted to the service. It is expected in the `id` key on the request body. |

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -91,7 +91,7 @@ const isHeadRequest = method => (method === 'HEAD');
 const redirectImageToWithinBounds = (params, response) => {
   const newLocation = `/${params.name}_${params.width}_${params.height}.${params.type}` +
     `?fit=${params.fit}&blur=${Boolean(params.blur)}&quality=${params.quality}`;
-  return response.status(307).set({
+  return response.status(303).set({
     'X-Redirect-Info': 'The requested image size falls outside of the allowed boundaries of this service. We are directing you to the closest available match.', //eslint-disable-line max-len
     'Location': newLocation
   }).end();
@@ -109,7 +109,7 @@ const redirectToCachedEntity = (cacheUrl, params, response) => {
     headers['Cache-Control'] = `max-age=${redirectTimeout}`;
   }
 
-  response.status(307).set(headers).end();
+  response.status(303).set(headers).end();
   response.end();
 };
 
@@ -176,7 +176,7 @@ export async function magic(params, method, response, stats = undefined, metric 
       if (metric) {
         metric.addTag('cacheHit', true);
         metric.addTag('withinBounds', true);
-        metric.addTag('status', 200);
+        metric.addTag('status', 303);
         metric.stop();
         metrics.write(metric);
         metrics.write(metric.copy(REDIRECT));
@@ -194,7 +194,7 @@ export async function magic(params, method, response, stats = undefined, metric 
       redirectToCachedEntity(cacheValue, params, response);
       if (metric) {
         metric.addFields(dbCache.stats());
-        metric.addTag('status', 200);
+        metric.addTag('status', 303);
         metric.addTag('withinBounds', true);
         metric.stop();
         metrics.write(metric);


### PR DESCRIPTION
This should make metrics a tad clearer, plus improve the way Google understands the redirect

