### PR TITLE
Allow direct proxying instead of redirecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "formidable": "^1.1.1",
     "gm": "^1.23.1",
     "influx": "^5.4.0",
+    "node-fetch": "^2.6.0",
     "pg": "^7.11.0",
     "pg-migration": "^1.0.6",
     "pg-native": "^3.0.0",

--- a/src/imageResponse.js
+++ b/src/imageResponse.js
@@ -1,3 +1,5 @@
+import {proxy} from "./proxy";
+
 require("babel-polyfill");
 
 import config from "config";
@@ -98,6 +100,10 @@ const redirectImageToWithinBounds = (params, response) => {
 };
 
 const redirectToCachedEntity = (cacheUrl, params, response) => {
+  if (params.proxy) {
+    proxy(cacheUrl, response);
+    return;
+  }
   // We redirect the user to the new location. We issue a temporary redirect such that the
   // request url stays the representitive url, and because temporary redirects generally
   // give less issues than permanent redirects for the odd chance that the underlying resource

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,0 +1,40 @@
+import http from 'http';
+import https from 'https';
+import fetch from 'node-fetch';
+import log from "./log";
+
+const httpAgent = new http.Agent({
+  keepAlive: true
+});
+const httpsAgent = new https.Agent({
+  keepAlive: true
+});
+
+const options = {
+  agent: function (_parsedURL) {
+    if (_parsedURL.protocol === 'http:') {
+      return httpAgent;
+    } else {
+      return httpsAgent;
+    }
+  },
+  // About 0.5MB of buffer size
+  highWaterMark: 512 * 1024
+};
+
+export async function proxy(cacheUrl, response) {
+  try {
+    // Fetch from CDN and proxy itself
+    const cacheResponse = await fetch(cacheUrl, options);
+    Array.from(cacheResponse.headers.entries())
+      .forEach(([header, headerValue]) => {
+        response.set(header, headerValue);
+      });
+    response.status(cacheResponse.status);
+    cacheResponse.body.pipe(response);
+  } catch (e) {
+    // Image not here apparently
+    log('error', `Critical error while proxying image: ${e}`);
+    response.status(500);
+  }
+}

--- a/src/urlParameters.js
+++ b/src/urlParameters.js
@@ -49,7 +49,8 @@ export default function urlToParams(req, requireDimensions = true) {
     type: 'jpg',
     mime: 'image/jpeg',
     fit: 'clip',
-    quality: -1
+    quality: -1,
+    proxy: false
   };
 
   // Extract data
@@ -73,6 +74,9 @@ export default function urlToParams(req, requireDimensions = true) {
     }
   }
 
+  if (req.query.proxy && req.query.proxy === 'true') {
+    result.proxy = true;
+  }
   if (req.query.fit && ALLOWED_FITS.includes(req.query.fit.toLowerCase())) {
     result.fit = req.query.fit.toLowerCase();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2346,6 +2346,11 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"


### PR DESCRIPTION
In order to allow eg crawlers from using the minimum of HTTP requests (think of Googles crawl budget), this adds the option of proxying the image directly from AWS Cloudfront through this service. It will kill any advantage you had by using a CDN in the first place, but when HTTP request count is important, it can be worth the trade off. It may not be a query param you'd want to set for all requests!

By using keepalives to the Cloudfront distribution, the overhead is minimized, and it performed approximately the same on local tests in terms of "time to finish". Also increased the nodejs buffer size a bit to allow for faster flushing