### PR TITLE
Reduce sizes of image on disk

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -1,3 +1,5 @@
+import { MAX_IMAGE_ON_DISK} from "./sizes";
+
 require("babel-polyfill");
 
 import fs from "fs";
@@ -186,7 +188,12 @@ export async function writeOriented(source, destination, cropParameters) {
     }
   }
 
-  const oriented = im(source).options(gmOptions).autoOrient();
+  const maxSizeAlongAxis = Math.floor(Math.sqrt(MAX_IMAGE_ON_DISK * 1e6));
+  const oriented = im(source).options(gmOptions)
+    .autoOrient()
+    // We also reduce the saved size a bit, so the size on disk is a lot smaller, which is essential for future conversions
+    // We'll only downscale, and maintain aspect ratios
+    .resize(maxSizeAlongAxis, maxSizeAlongAxis, ">");
 
   try {
     await write(oriented, destination);

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,7 @@ import timingMetric from "./metrics/timingMetric";
 import database from './databases';
 import robotsTxt, {syncRobotsTxt} from "./robotsTxt";
 import startMigrations from './migrations';
-
-const MAX_IMAGE_IN_MP = (config.has('constraints.max_input') && config.get('constraints.max_input')) || 30;
+import {MAX_IMAGE_IN_MP} from "./sizes";
 
 process.on('uncaughtException', function (err) {
   log('error', err);

--- a/src/sizes.js
+++ b/src/sizes.js
@@ -1,0 +1,4 @@
+import config from 'config';
+
+export const MAX_IMAGE_IN_MP = (config.has('constraints.max_input') && config.get('constraints.max_input')) || 30;
+export const MAX_IMAGE_ON_DISK = (config.has('constraints.max_on_disk') && config.get('constraints.max_on_disk')) || 10;


### PR DESCRIPTION
This reduces the size of images on disk, so for future conversions a lower resolution image can be leveraged.

Note that some other properties in `/etc/ImageMagick-6/policy.xml` still affect conversions